### PR TITLE
fix: Python docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Use these documentation files to understand how Pieces Client works.
 |---|---|
 | 🗄 Dart | [To Documentation](https://github.com/pieces-app/pieces-os-client-sdk-for-dart/tree/main/doc) |
 | 🗄 Kotlin | [To Documentation](https://github.com/pieces-app/pieces-os-client-sdk-for-kotlin/tree/main/docs) |
-| 🗄 Python | [To Documentation](https://github.com/pieces-app/pieces-os-client-sdk-for-python/tree/main/docs/docs) |
+| 🗄 Python | [To Documentation](https://github.com/pieces-app/pieces-os-client-sdk-for-python/tree/main/docs) |
 | 🗄 Typescript | (coming soon) |
 
 ## SDKs


### PR DESCRIPTION
# Description
This pull request fixes a broken link in the Python documentation that was leading to a 404 error. The issue was caused by an extra "/docs" segment present in the URL.

## Changes:

- Removed the unnecessary "/docs" segment from the Python documentation link(s).
- Verified that the corrected link(s) now point(s) to the intended documentation target.